### PR TITLE
feat: set dynamic browser tab title (#1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,15 @@ export default function App() {
   // import.meta.env.BASE_URL is injected at build time and never changes
   const BASE = import.meta.env.BASE_URL;
 
+  // ▶ NEW: set tab title
+  useEffect(() => {
+    if (data?.painting?.title) {
+      document.title = `${data.painting.title} – ArtContext Viewer`;
+    } else {
+      document.title = 'ArtContext Viewer';
+    }
+  }, [data]);
+
   useEffect(() => {
     fetch(`${BASE}data/nightwatch.labels.json`)
       .then((r) => {


### PR DESCRIPTION
### ✨ What’s new
* Sets the browser tab title dynamically:
  * Defaults to **ArtContext Viewer** while the app is loading.
  * Updates to **"<painting-title> – ArtContext Viewer"** once the JSON loads.

### ✅ How to test
1. `npm run dev`
2. Observe tab title switches from the default to **The Night Watch – ArtContext Viewer** after data fetch.

Closes #1
